### PR TITLE
ftl_protocol: Improve error handling

### DIFF
--- a/crates/ftl/src/protocol/error.rs
+++ b/crates/ftl/src/protocol/error.rs
@@ -1,12 +1,18 @@
+use std::string::ToString;
+
 #[derive(Debug)]
 pub enum FtlError {
-    NoLabel,
     IoError,
+    AllocateError,
     RingError,
     DecodeError,
     MissingPart,
-    ExternalError,
-    Unauthenticated,
+
+    InvalidStreamKey, // applies to channel id as well
+    ChannelNotAuthorized,
+    ChannelInUse,
+    UnsupportedRegion,
+    GameBlocked,
     
     InvalidProtocolVersion,
     UnsupportedProtocolVersion,
@@ -21,6 +27,30 @@ impl FtlError {
         match self {
             FtlError::Disconnect => false,
             _ => true
+        }
+    }
+}
+
+impl ToString for FtlError {
+    fn to_string(&self) -> String {
+        match self {
+            FtlError::IoError => "500 Internal Server Error\n".to_string(),
+            FtlError::AllocateError => "500 Internal Server Error\n".to_string(),
+            FtlError::RingError => "400 HMAC Decode Error\n".to_string(),
+            FtlError::DecodeError => "400 HMAC Decode Error\n".to_string(),
+            FtlError::MissingPart => "400 Bad Request\n".to_string(),
+
+            FtlError::InvalidStreamKey => "405 Invalid stream key\n".to_string(),
+            FtlError::ChannelNotAuthorized => "401 Channel not authorized to stream\n".to_string(),
+            FtlError::ChannelInUse => "406 Channel actively streaming\n".to_string(),
+            FtlError::UnsupportedRegion => "407 Streaming from your region is not authorized\n".to_string(),
+            FtlError::GameBlocked => "409 Channel is not allowed to stream set game\n".to_string(),
+
+            FtlError::InvalidProtocolVersion => "400 Invalid Protocol Version\n".to_string(),
+            FtlError::UnsupportedProtocolVersion => "402 Outdated FTL SDK version\n".to_string(),
+            FtlError::MissingCodecInformation => "400 Missing Codec Information\n".to_string(),
+            FtlError::UnimplementedCommand => "901 Invalid Command\n".to_string(),
+            _ => "".to_string(),
         }
     }
 }

--- a/crates/ftl/src/server.rs
+++ b/crates/ftl/src/server.rs
@@ -53,7 +53,6 @@ pub trait IngestServer {
                                                     error!("Failed to execute FTL command. {:?}", error);
                                                 }
 
-                                                client.should_stop.store(true, Ordering::Relaxed);
                                                 break;
                                             }
                                         } else {
@@ -77,6 +76,7 @@ pub trait IngestServer {
                 }
 
                 info!("Remote FTL client disconnected.");
+                client.should_stop.store(true, Ordering::Relaxed);
                 stream.shutdown(std::net::Shutdown::Both).ok();
             });
         }


### PR DESCRIPTION
This pull request improves error handling by properly responding to the client about what went wrong.

It also fixes an issue where there would be a port allocation leak if the streamer's client did not exit cleanly.